### PR TITLE
Revert unsaved reminder btn - Closes #12

### DIFF
--- a/app/components/edit-reminder.js
+++ b/app/components/edit-reminder.js
@@ -6,7 +6,12 @@ export default Ember.Component.extend({
   actions: {
     updateReminder() {
       this.get('store').findRecord('reminder', this.model.id).then(reminder => {
-        reminder.save()
+        reminder.save();
+      })
+    },
+    undoChanges() {
+      this.get('store').findRecord('reminder', this.model.id).then(reminder => {
+        reminder.rollbackAttributes();
       })
     }
   }

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -13,8 +13,10 @@
       {{textarea class='new-reminder-notes' type='text' value=model.notes cols='80' rows='6'}}
     </label>
     {{#link-to 'reminders.reminder' model.id}}
-      <button class='save-updates-btn' {{action 'updateReminder' on='click'}}>Save</button>
+      <button class='save-updates-btn' {{action 'updateReminder'}}>Save</button>
     {{/link-to}}
-    <button class='undo-updates-btn' {{action 'undoChanges' on='click'}}>Undo</button>
+    {{#if model.hasDirtyAttributes}}
+      <button class='undo-updates-btn' {{action 'undoChanges'}}>Undo</button>
+    {{/if}}
   </form>
 </div>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -13,8 +13,8 @@
       {{textarea class='new-reminder-notes' type='text' value=model.notes cols='80' rows='6'}}
     </label>
     {{#link-to 'reminders.reminder' model.id}}
-      <button {{action 'updateReminder' on='click'}}>Save</button>
+      <button class='save-updates-btn' {{action 'updateReminder' on='click'}}>Save</button>
     {{/link-to}}
-    <button {{action 'undoChanges' on='click'}}>Undo</button>
+    <button class='undo-updates-btn' {{action 'undoChanges' on='click'}}>Undo</button>
   </form>
 </div>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -1,5 +1,5 @@
 <div class='active indiv-reminder-display'>
-  <form class='edit-reminder-form' {{action 'updateReminder' on='submit'}}>
+  <form class='edit-reminder-form'>
     <label>
       Title
       {{input class='new-reminder-title' type='text' value=model.title}}
@@ -13,7 +13,8 @@
       {{textarea class='new-reminder-notes' type='text' value=model.notes cols='80' rows='6'}}
     </label>
     {{#link-to 'reminders.reminder' model.id}}
-      <button type='submit' class='save-updates-btn'>Save</button>
+      <button {{action 'updateReminder' on='click'}}>Save</button>
     {{/link-to}}
+    <button {{action 'undoChanges' on='click'}}>Undo</button>
   </form>
 </div>

--- a/tests/acceptance/edit-reminder-test.js
+++ b/tests/acceptance/edit-reminder-test.js
@@ -46,3 +46,16 @@ test('redirects from /edit after clicking save', function(assert) {
     assert.equal(currentURL(), '/reminders/1')
   })
 })
+
+test('reverts to saved changes when revert button clicked', function(assert) {
+  let initialTitle = find('.new-reminder-title').val()
+  fillIn('.new-reminder-title', 'Awesome Title')
+
+  andThen(function() {
+    assert.equal(find('.new-reminder-title').val(), 'Awesome Title', 'should accept new title input')
+  })
+  click('.undo-updates-btn')
+  andThen(function() {
+    assert.equal(find('.new-reminder-title').val(), initialTitle, 'should revert to initial title')
+  })
+})

--- a/tests/integration/components/edit-reminder-test.js
+++ b/tests/integration/components/edit-reminder-test.js
@@ -22,5 +22,10 @@ test('renders data from its model prop', function(assert) {
 
 test('renders a save button', function(assert) {
   this.render(hbs`{{edit-reminder model=model}}`)
-  assert.equal(this.$('button').text(), 'Save')
+  assert.equal(this.$('.save-updates-btn').text(), 'Save')
+})
+
+test('renders a undo button', function(assert) {
+  this.render(hbs`{{edit-reminder model=model}}`)
+  assert.equal(this.$('.undo-updates-btn').text(), 'Undo')
 })


### PR DESCRIPTION
@martensonbj @Tman22 
Closes #12  
## Purpose

The PR adds an 'undo' button to the edit-reminder view so that unsaved changes can be removed.

## Approach

We added a button to the edit-reminder component that cleaned up dirty data, if present on a specific reminder.

### Test coverage 

We've added a new acceptance and integration test for this functionality.

### Follow-up tasks

Issue #13 