### PR TITLE
Unsaved reminder cues - closes Issue #13

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -56,3 +56,11 @@ a {
 .btn:hover {
   cursor: pointer;
 }
+
+.reminder-status {
+  color: green;
+}
+
+.tay-tay {
+  color: red;
+}

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -41,6 +41,14 @@ a {
   margin: 10px;
 }
 
+.spec-reminder-item {
+  display: flex;
+  flex-direction: row;
+}
+.spec-reminder-item p {
+  margin-left: 5px;
+}
+
 .add-reminder-btn {
   width: 100px;
 }

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -4,7 +4,7 @@
       {{#link-to 'reminders.reminder' reminder.id}}
         <div class='spec-reminder-item' >
           <h3 class='spec-reminder-title'>{{reminder.title}}</h3>
-          <p class='reminder-status clean'>☑</p>
+          <p class='reminder-status {{if reminder.hasDirtyAttributes "tay-tay"}}'>☑</p>
         </div>
       {{/link-to}}
     {{/each}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -4,9 +4,7 @@
       {{#link-to 'reminders.reminder' reminder.id}}
         <div class='spec-reminder-item' >
           <h3 class='spec-reminder-title'>{{reminder.title}}</h3>
-          <p class='spec-reminder-date'>{{reminder.date}}</p>
-          <p class='spec-reminder-notes'>{{reminder.notes}}</p>
-          <br>
+          <p class='reminder-status clean'>☑</p>
         </div>
       {{/link-to}}
     {{/each}}

--- a/tests/acceptance/edit-reminder-test.js
+++ b/tests/acceptance/edit-reminder-test.js
@@ -59,3 +59,16 @@ test('reverts to saved changes when revert button clicked', function(assert) {
     assert.equal(find('.new-reminder-title').val(), initialTitle, 'should revert to initial title')
   })
 })
+
+test('tay-tay class toggles when reminder has dirty data', function(assert) {
+  fillIn('.new-reminder-title', 'Awesome Title')
+
+  andThen(function() {
+    assert.equal(find('.tay-tay').length, 1, 'should have tay-tay class when dirty data exists')
+  })
+  click('.undo-updates-btn')
+
+  andThen(function() {
+    assert.equal(find('.tay-tay').length, 0, 'should no longer have tay-tay class when dirty data exists')
+  })
+})

--- a/tests/acceptance/new-reminder-test.js
+++ b/tests/acceptance/new-reminder-test.js
@@ -27,12 +27,8 @@ test('should add a new reminder', function(assert) {
     andThen(function() {
       assert.equal(currentURL(), 'reminders/new');
       assert.equal(find('.spec-reminder-title').length, 1, 'should return a title field for new reminder')
-      assert.equal(find('.spec-reminder-date').length, 1, 'should return a date field for new reminder')
-      assert.equal(find('.spec-reminder-notes').length, 1, 'should return a notes field for new reminder')
 
       assert.equal(find('.spec-reminder-title').text(), 'Tell black bear his fly is unzipped', 'should show correct title for new reminder')
-      assert.equal(find('.spec-reminder-date').text(), '2017-02-10', 'should show correct date for new reminder')
-      assert.equal(find('.spec-reminder-notes').text(), 'He is embarrassing himself infront of everyone', 'should show correct notes for new reminder')
     })
   });
 });


### PR DESCRIPTION
@Tman22 @martensonbj 
Closes #13 

## Purpose

Added a visual cue to the reminders list to illustrate when there is dirty data (aka 'tay-tay' data)

## Approach

We added a conditional within the class of the individual reminder elements based on whether or not there is 'tay-tay' data present.

### Test coverage 

We wrote tests to confirm that the class name is toggling correctly when there is and is not 'tay-tay' data.

### Follow-up tasks

#14 (already DONE!)