### PR TITLE
Remove Reminder functionality with tests

### DIFF
--- a/app/components/delete-reminder.js
+++ b/app/components/delete-reminder.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+
+  actions: {
+    deleteReminder() {
+      this.get('store').findRecord('reminder', this.model.id, {backgroundReload: false }).then(reminder => {
+        reminder.destroyRecord();
+      })
+    }
+  }
+});

--- a/app/templates/components/delete-reminder.hbs
+++ b/app/templates/components/delete-reminder.hbs
@@ -1,0 +1,1 @@
+<button class='delete-reminder-btn btn' {{action 'deleteReminder'}}>Delete</button>

--- a/app/templates/components/edit-reminder.hbs
+++ b/app/templates/components/edit-reminder.hbs
@@ -18,5 +18,10 @@
     {{#if model.hasDirtyAttributes}}
       <button class='undo-updates-btn' {{action 'undoChanges'}}>Undo</button>
     {{/if}}
+
+    {{#link-to 'reminders'}}
+      {{delete-reminder model=model}}
+    {{/link-to}}
+
   </form>
 </div>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -7,6 +7,11 @@
           <p class='reminder-status {{if reminder.hasDirtyAttributes "tay-tay"}}'>☑</p>
         </div>
       {{/link-to}}
+
+      {{#link-to 'reminders'}}
+        {{delete-reminder model=reminder}}
+      {{/link-to}}
+
     {{/each}}
   {{else}}
     <h3 class='no-reminder-message'>Click below to add a new reminder.</h3>

--- a/tests/acceptance/edit-reminder-test.js
+++ b/tests/acceptance/edit-reminder-test.js
@@ -38,6 +38,14 @@ test('updates value on save', function(assert) {
   })
 })
 
+test('toggle Undo button', function(assert) {
+  assert.equal(find('.undo-updates-btn').length, 0, 'does not render undo button if no changes are made')
+  fillIn('.new-reminder-title')
+  andThen(function() {
+    assert.equal(find('.undo-updates-btn').length, 1, 'renders undo button if changes have been made')
+  })
+})
+
 test('redirects from /edit after clicking save', function(assert) {
   fillIn('.new-reminder-title', 'Awesome Title')
   click('.save-updates-btn')
@@ -71,4 +79,14 @@ test('tay-tay class toggles when reminder has dirty data', function(assert) {
   andThen(function() {
     assert.equal(find('.tay-tay').length, 0, 'should no longer have tay-tay class when dirty data exists')
   })
+})
+
+test('delete button functionality', function(assert) {
+  click('.delete-reminder-btn')
+  andThen(function() {
+    assert.equal(currentURL(), '/reminders', 'delete button should redirect to /reminders route')
+    assert.equal(find('.spec-reminder-item').length, 0, 'should not feature reminder on main reminder list')
+  })
+
+
 })

--- a/tests/acceptance/edit-reminder-test.js
+++ b/tests/acceptance/edit-reminder-test.js
@@ -82,6 +82,8 @@ test('tay-tay class toggles when reminder has dirty data', function(assert) {
 })
 
 test('delete button functionality', function(assert) {
+  assert.equal(currentURL(), '/reminders/1/edit')
+  assert.equal(find('.spec-reminder-item').length, 1, 'assert that the reminder exists on the dom')
   click('.delete-reminder-btn')
   andThen(function() {
     assert.equal(currentURL(), '/reminders', 'delete button should redirect to /reminders route')

--- a/tests/acceptance/reminders-test.js
+++ b/tests/acceptance/reminders-test.js
@@ -40,3 +40,34 @@ test('message display when no notes are in storage', function(assert) {
     assert.equal(find('.no-reminder-message').text(), 'Click below to add a new reminder.', 'should display prompt to add reminders if none exist')
   })
 })
+
+  test('delete button functionality', function(assert) {
+    server.createList('reminder', 5);
+    visit('/reminders');
+
+    andThen(function() {
+      assert.equal(find('.delete-reminder-btn').length, 5, 'should have 5 delete buttons')
+    })
+
+    click('.delete-reminder-btn:first')
+
+    andThen(function() {
+      assert.equal(find('.delete-reminder-btn').length, 4, 'deleting an items should take away one reminder (and delete button)')
+    })
+  })
+
+  test('delete button on edit page', function(assert) {
+    server.createList('reminder', 5);
+    visit('/reminders');
+    click('.spec-reminder-item:first')
+    click('.edit-reminder-btn')
+
+    andThen(function() {
+      assert.equal(currentURL(), '/reminders/1/edit');
+    })
+    click('.edit-reminder-form .delete-reminder-btn')
+
+    andThen(function() {
+      assert.equal(find('.spec-reminder-item').length, 4, 'should remove reminder from page if delete is clicked in edit view')
+    })
+  })

--- a/tests/integration/components/delete-reminder-test.js
+++ b/tests/integration/components/delete-reminder-test.js
@@ -1,0 +1,16 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('delete-reminder', 'Integration | Component | delete reminder', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  this.render(hbs`{{delete-reminder}}`);
+  assert.equal(this.$('.delete-reminder-btn').length, 1, 'should render a single button');
+});
+
+test('it has text of Delete', function(assert) {
+  this.render(hbs`{{delete-reminder}}`);
+  assert.equal(this.$('.delete-reminder-btn').text(), 'Delete', "should have 'Delete' text on button ");
+});

--- a/tests/integration/components/edit-reminder-test.js
+++ b/tests/integration/components/edit-reminder-test.js
@@ -25,7 +25,7 @@ test('renders a save button', function(assert) {
   assert.equal(this.$('.save-updates-btn').text(), 'Save')
 })
 
-test('renders a undo button', function(assert) {
+test('does NOT render an undo button before changes are made', function(assert) {
   this.render(hbs`{{edit-reminder model=model}}`)
-  assert.equal(this.$('.undo-updates-btn').text(), 'Undo')
+  assert.equal(this.$('.undo-updates-btn').text(), '')
 })


### PR DESCRIPTION
@martensonbj @Tman22 
Closes #14 

## Purpose

Adds ability to delete reminders from main list as well as from the edit reminder view.

## Approach

Created a single delete-reminder component to be utilized in two places.

### Learning

Docs, docs, docs and more docs.

### Test coverage 

Component tested to ensure it has the necessary stuff. 
Acceptance testing to ensure that deleting a record redirects and removes reminder from the dom.

### Follow-up tasks

Future issues and styles